### PR TITLE
implement get_book route to retrieve book by ID and handle 404 errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: test
+
+on:
+    pull_request:
+        branches:
+            - main
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+
+            - name: Set up Python
+              uses: actions/setup-python@v2
+              with:
+                  python-version: "3.x"
+
+            - name: Install dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install -r requirements.txt
+
+            - name: Run tests with pytest
+              run: |
+                  pytest

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -1,6 +1,6 @@
 from typing import OrderedDict
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, status, HTTPException
 from fastapi.responses import JSONResponse
 
 from api.db.schemas import Book, Genre, InMemoryDB
@@ -60,3 +60,10 @@ async def update_book(book_id: int, book: Book) -> Book:
 async def delete_book(book_id: int) -> None:
     db.delete_book(book_id)
     return JSONResponse(status_code=status.HTTP_204_NO_CONTENT, content=None)
+
+@router.get("/{book_id}", status_code=status.HTTP_200_OK)
+def get_book(book_id: int):
+    book = db.get_book(book_id)
+    if not book:
+        raise HTTPException(status_code=404, detail="Book not found")
+    return book


### PR DESCRIPTION
# feat: implement get_book route to retrieve book by ID and handle 404 errors

## Description
Added a `get_book` route to retrieve a book by its ID. The route returns a 200 OK status with book details if the book exists, or a 404 Not Found status with an appropriate error message if the book is not found. The function uses `InMemoryDB.get_book()` to fetch the book data from the in-memory database.

## Related Issue (Link to issue ticket)
N/A

## Motivation and Context
This change is required to allow users to fetch book details by providing a book ID. It solves the problem of querying for specific book information from the database and handling invalid IDs gracefully with a 404 error response.

## How Has This Been Tested?
- Tested locally using FastAPI's Uvicorn server.
- Verified that valid book IDs return the correct book details with a 200 OK response.
- Checked that invalid book IDs result in a 404 Not Found response with the error message "Book not found".

## Screenshots (if appropriate - Postman, etc):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
