### PR TITLE
Implemented get book by ID endpoint

### DIFF
--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -47,6 +47,17 @@ async def create_book(book: Book):
 async def get_books() -> OrderedDict[int, Book]:
     return db.get_books()
 
+# implementation of missing endpoint
+
+@router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
+async def get_book(book_id: int) -> Book:
+    book = db.get_book(book_id)
+    if not book:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"detail": "Book not found"}
+        )
+    return book
 
 @router.put("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
 async def update_book(book_id: int, book: Book) -> Book:


### PR DESCRIPTION
## Description
- Added the missing endpoint GET `/api/v1/books/{book_id}` to retrieve a single book detail.
- Configured Nginx reverse proxy for FastAPI.

## Related Task
[HNG12 Stage 2 Task](https://github.com/hng12-devbotops/fastapi-book-project)

## Testing
- Ran `pytest` locally (all tests passed).
- Tested invalid IDs (e.g., `/books/377`) to confirm 404 response.

## Notes
- Invited [@hng12-devbotops](https://github.com/hng12-devbotops) as a collaborator.
- Deployment URL: [`https://immense-adelina-kenward-edde1597.koyeb.app/`](https://immense-adelina-kenward-edde1597.koyeb.app/)